### PR TITLE
ubuntu_cosmic: add branch based on ubuntu_bionic

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Current branches and their dependencies:
 * `ungoogled_debian_stretch`: `ungoogled_debian_buster`, `upstream/stretch`
 * `ungoogled_debian_minimal`: `ungoogled_debian_buster`
 * `ungoogled_ubuntu_bionic`: `ungoogled_debian_buster`
+* `ungoogled_ubuntu_cosmic`: `ungoogled_debian_buster`
 
 All branches with the `ungoogled_` prefix correspond to a:
 

--- a/debian/changelog.ungoogin
+++ b/debian/changelog.ungoogin
@@ -1,4 +1,4 @@
-ungoogled-chromium-browser ($ungoog{chromium_version}-$ungoog{release_revision}~bionic) bionic; urgency=medium
+ungoogled-chromium-browser ($ungoog{chromium_version}-$ungoog{release_revision}~cosmic) cosmic; urgency=medium
 
   * Built against $ungoog{current_commit_or_tag}
 

--- a/debian/ungoogled-config-bundle
+++ b/debian/ungoogled-config-bundle
@@ -1,1 +1,1 @@
-ubuntu_bionic
+ubuntu_cosmic


### PR DESCRIPTION
Create a build branch for Ubuntu 18.10 (cosmic) based on bionic.
As described already in https://github.com/Eloston/ungoogled-chromium/pull/603 only "cosmetic" changes were required.

:exclamation:  Please "merge" this into a new branch called `ungoogled_ubuntu_cosmic`.

BTW: thanks for the updated docs. It was basically copy and paste. :+1: 