### PR TITLE
Fix `ubuntu_cosmic` build for 72.0.3626.122

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -84,7 +84,6 @@ defines+=use_gio=true \
          use_system_lcms2=true \
          use_system_libjpeg=true \
          use_system_freetype=true \
-         use_system_harfbuzz=true \
          use_jumbo_build=true \
          jumbo_file_merge_limit=8 \
          proprietary_codecs=true \


### PR DESCRIPTION
The new structure looks good. The only missing piece for `ubuntu_cosmic` was the ["Disable system harfbuzz" commit](https://github.com/ungoogled-software/ungoogled-chromium-debian/commit/2a4a87f0d63b754d7164e2a84d51151a6574544c) from `ubuntu_bionic`.

You could then tag `72.0.3626.122-3.cosmic1`. :wink: 