### PR TITLE
Add new branch for Ubuntu 19.04 (disco)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 This repository contains files to build Debian packages of [ungoogled-chromium](//github.com/Eloston/ungoogled-chromium).
 
-This branch contains the code to build packages for: **Debian 10 (buster)**
+This branch contains the code to build packages for: **Ubuntu 19.04 (disco)**
 
 ## Downloads
 
 **Binaries** (i.e. `.deb` packages): [Get them from the Contributor Binaries website](//ungoogled-software.github.io/ungoogled-chromium-binaries/).
 
-**Source Code**: Use the tags labeled with `buster` via `git checkout` (see building instructions). The branches are for development and may not be stable.
+**Source Code**: Use the tags labeled with `disco` via `git checkout` (see building instructions). The branches are for development and may not be stable.
 
 ## Installing
 
@@ -48,13 +48,6 @@ cd build/src
 
 # Final setup steps for debian/ directory
 ./debian/rules setup-debian
-
-# Add packages for LLVM 8
-# The easiest way to do this is to use the APT repo from apt.llvm.org
-# 1. Add this line to your /etc/apt/sources.list: deb http://apt.llvm.org/buster/ llvm-toolchain-buster-8 main
-# 2. Follow the instructions on https://apt.llvm.org for adding the signing key
-#
-# You do not need to install LLVM packages yourself, since the next step will do it for you.
 
 # Install remaining requirements to build Chromium
 sudo mk-build-deps -i debian/control
@@ -116,11 +109,11 @@ git remote add upstream https://salsa.debian.org/chromium-team/chromium.git
 
 ### Pull new changes from Debian
 
-These instructions will pull in changes from Debian's `chromium` package into `debian_buster`:
+First, update `debian_buster` with the latest changes. Then, merge it into this branch:
 
 ```sh
-git checkout --recurse-submodules debian_buster
-git pull upstream master
+git checkout --recurse-submodules ubuntu_disco
+git merge debian_buster
 # Complete the git merge
 # Update patches via instructions below
 ```

--- a/debian/changelog.ungoogin
+++ b/debian/changelog.ungoogin
@@ -1,4 +1,4 @@
-ungoogled-chromium ($ungoog{chromium_version}-$ungoog{ungoogled_revision}.buster$ungoog{distro_revision}) buster; urgency=medium
+ungoogled-chromium ($ungoog{chromium_version}-$ungoog{ungoogled_revision}.disco$ungoog{distro_revision}) disco; urgency=medium
 
   * Built against $ungoog{ungoogled_version}
 

--- a/debian/devutils/print_tag_version.sh
+++ b/debian/devutils/print_tag_version.sh
@@ -3,4 +3,4 @@
 _debian_dir=$(dirname $(dirname $(readlink -f $0)))
 _ungoogled_repo=$_debian_dir/ungoogled-upstream/ungoogled-chromium
 
-printf '%s-%s.buster%s' $(cat $_ungoogled_repo/chromium_version.txt) $(cat $_ungoogled_repo/revision.txt) $(cat $_debian_dir/distro_revision.txt)
+printf '%s-%s.disco%s' $(cat $_ungoogled_repo/chromium_version.txt) $(cat $_ungoogled_repo/revision.txt) $(cat $_debian_dir/distro_revision.txt)

--- a/debian/patches/fixes/vaapi.patch
+++ b/debian/patches/fixes/vaapi.patch
@@ -3,17 +3,15 @@ author: Akarshan Biswas <akarshan.biswas@gmail.com>
 
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -1663,8 +1663,8 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -1663,7 +1663,7 @@ const FeatureEntry kFeatureEntries[] = {
          "disable-accelerated-video-decode",
          flag_descriptions::kAcceleratedVideoDecodeName,
          flag_descriptions::kAcceleratedVideoDecodeDescription,
 -        kOsMac | kOsWin | kOsCrOS | kOsAndroid,
--        SINGLE_DISABLE_VALUE_TYPE(switches::kDisableAcceleratedVideoDecode),
 +        kOsMac | kOsWin | kOsCrOS | kOsAndroid | kOsLinux,
-+        SINGLE_VALUE_TYPE(switches::kDisableAcceleratedVideoDecode),
+         SINGLE_DISABLE_VALUE_TYPE(switches::kDisableAcceleratedVideoDecode),
      },
  #if defined(OS_WIN)
-     {"enable-hdr", flag_descriptions::kEnableHDRName,
 @@ -2273,12 +2273,12 @@ const FeatureEntry kFeatureEntries[] = {
       FEATURE_VALUE_TYPE(service_manager::features::kXRSandbox)},
  #endif  // ENABLE_ISOLATED_XR_SERVICE


### PR DESCRIPTION
This branch is based on `debian_buster` with minimal changes:
- removed steps for adding upstream LLVM-8 repo, because `disco` ships with it already
- ~added [section on use with external ungoogled-chromium repo](https://github.com/ungoogled-software/ungoogled-chromium-debian/compare/debian_buster...riyad:ubuntu_disco?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R147) from `ubuntu_bionic`~
- reverted fix for #9 because of https://github.com/ungoogled-software/ungoogled-chromium-debian/issues/9#issuecomment-485868553


Todo on merge:
- create new `ubuntu_disco` branch