### PR TITLE
Add new branch for Ubuntu 19.10 (eoan)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,13 @@ If you're going to backport a branch for a newer distro version onto an older di
 Contribution guidelines are the same as ungoogled-chromium.
 
 Submit PRs to this repository for every packaging type that should be updated.
+
+## Differences between Debian's Chromium
+
+There are a few differences with Debian's Chromium:
+
+* Modified default CLI flags and preferences; see `debian/etc/default-flags` and `debian/etc/master_preferences`
+* Uses LLVM toolchain instead of GCC
+* Add flag for VA-API acceleration (`chrome://flags/#disable-accelerated-video-decode`)
+* Use GTK3 (Chromium's default) instead of GTK2
+* Enable more FFMpeg codecs by default

--- a/README.md
+++ b/README.md
@@ -200,6 +200,23 @@ To add either a primary or secondary branch:
 	* e.g. `git tag -s $(./debian/devutils/print_tag_version.sh)`
 	* NOTE: This requires that `debian/ungoogled-upstream/ungoogled-chromium` contains the ungoogled-chromium repo files.
 
+### Notes on updating older branches
+
+If you're going to backport a branch for a newer distro version onto an older distro branch, you will need to either:
+
+1. Try to use the older system library: Change `debian/control` to use an older version and get patches for Chromium to work with the older system library.
+2. Use the bundled system library instead:
+  1. If you are merging a newer distro's branch into an older distro's branch, and the older distro's branch removed the system library, git may automatically strip out most, if not all, the code to use the system library.
+  2. For libraries like ICU or VA-API, there may be commits in the history that added or removed the library (try a search on the commit history). You can try cherry-picking them, or using them as a reference.
+  3. Remove the dependency in `debian/control`
+  4. Determine the library's name under Chromium's `third_party/` directory. We will refer to this name as `$LIB_NAME` below. Note that there are multiple `third_party` directories; the most common one is at the root of the Chromium source tree. Another one you may see is `base/third_party`. The following instructions still apply regardless of which `third_party` directory you use.
+  5. Add `$LIB_NAME` to the `keepers` tuple in `debian/scripts/unbundle`. Also, check for any special removal logic, such as calls to functions `strip` and `remove_file`.
+  6. Remove any filepaths including `third_party/$LIB_NAME` in `debian/clean`.
+  7. Some libraries may produce additional build outputs (e.g. switching back to bundled ICU). In this scenario, you will need to add the build outputs into the relevant package's `.install` file. See `debian/control` for what the different packages are.
+  8. Check for any special rules in `debian/rules` dealing with your library under `third_party/$LIB_NAME`
+  9. Remove any entries involving `third_party/$LIB_NAME` from the `Files-Excluded` section of `debian/copyright`
+  10. Remove any patches from `debian/patches/` relating to your library.
+
 ### Contributing
 
 Contribution guidelines are the same as ungoogled-chromium.

--- a/README.md
+++ b/README.md
@@ -55,9 +55,14 @@ cd build/src
 ./debian/rules setup-debian
 
 # Add packages for LLVM 8
-# The easiest way to do this is to use the APT repo from apt.llvm.org
+# One way to do this is to install from buster-backports:
+# 1. Add this line to your /etc/apt/sources.list: deb http://deb.debian.org/debian/ buster-backports main
+# 2. Run "apt update"
+#
+# Another way is to use the APT repo from apt.llvm.org
 # 1. Add this line to your /etc/apt/sources.list: deb http://apt.llvm.org/buster/ llvm-toolchain-buster-8 main
 # 2. Follow the instructions on https://apt.llvm.org for adding the signing key
+# 3. Run "apt update"
 #
 # You do not need to install LLVM packages yourself, since the next step will do it for you.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains files to build Debian packages of [ungoogled-chromium](//github.com/Eloston/ungoogled-chromium).
 
-This branch contains the code to build packages for: **Ubuntu 19.04 (disco)**
+This branch contains the code to build packages for: **Ubuntu 19.10 (eoan)**
 
 ## Downloads
 
@@ -10,7 +10,7 @@ This branch contains the code to build packages for: **Ubuntu 19.04 (disco)**
 
 If your distro is not listed, you may have a look at the [community-maintained list of packages compatible on other distros](https://github.com/ungoogled-software/ungoogled-chromium-debian/wiki/Compatible-Packages). However, please note that this compatibility is not guarenteed; it may break at any time.
 
-**Source Code**: Use the tags labeled with `disco` via `git checkout` (see building instructions). The branches are for development and may not be stable.
+**Source Code**: Use the tags labeled with `eoan` via `git checkout` (see building instructions). The branches are for development and may not be stable.
 
 ## Installing
 
@@ -34,7 +34,7 @@ The other packages are as follows:
 
 ```sh
 # Install essential requirements
-sudo apt install git python3 packaging-dev
+sudo apt install git python3 packaging-dev equivs
 
 # Setup build tree under build/
 mkdir -p build/src
@@ -117,7 +117,7 @@ git remote add upstream https://salsa.debian.org/chromium-team/chromium.git
 First, update `debian_buster` with the latest changes. Then, merge it into this branch:
 
 ```sh
-git checkout --recurse-submodules ubuntu_disco
+git checkout --recurse-submodules ubuntu_eoan
 git merge debian_buster
 # Complete the git merge
 # Update patches via instructions below

--- a/debian/changelog.ungoogin
+++ b/debian/changelog.ungoogin
@@ -1,4 +1,4 @@
-ungoogled-chromium ($ungoog{chromium_version}-$ungoog{ungoogled_revision}.disco$ungoog{distro_revision}) disco; urgency=medium
+ungoogled-chromium ($ungoog{chromium_version}-$ungoog{ungoogled_revision}.eoan$ungoog{distro_revision}) eoan; urgency=medium
 
   * Built against $ungoog{ungoogled_version}
 

--- a/debian/control
+++ b/debian/control
@@ -9,9 +9,9 @@ Standards-Version: 4.4.0
 Rules-Requires-Root: no
 Build-Depends:
  debhelper (>= 11),
- clang-8,
- lld-8,
- llvm-8-dev,
+ clang,
+ lld,
+ llvm-dev,
  python,
  python3,
  pkg-config,

--- a/debian/devutils/print_tag_version.sh
+++ b/debian/devutils/print_tag_version.sh
@@ -3,4 +3,4 @@
 _debian_dir=$(dirname $(dirname $(readlink -f $0)))
 _ungoogled_repo=$_debian_dir/ungoogled-upstream/ungoogled-chromium
 
-printf '%s-%s.disco%s' $(cat $_ungoogled_repo/chromium_version.txt) $(cat $_ungoogled_repo/revision.txt) $(cat $_debian_dir/distro_revision.txt)
+printf '%s-%s.eoan%s' $(cat $_ungoogled_repo/chromium_version.txt) $(cat $_ungoogled_repo/revision.txt) $(cat $_debian_dir/distro_revision.txt)

--- a/debian/rules
+++ b/debian/rules
@@ -82,6 +82,7 @@ defines+=is_debug=false \
          use_unofficial_version_number=false \
          enable_iterator_debugging=false \
          enable_vr=false \
+         enable_swiftshader=false \
          optimize_webui=false \
          linux_use_bundled_binutils=false \
 

--- a/debian/rules
+++ b/debian/rules
@@ -10,17 +10,17 @@ export DEB_BUILD_MAINT_OPTIONS=hardening=+all
 export DEB_RULES_REQUIRES_ROOT=no
 
 # use system LLVM via unbundling
-export AR=llvm-ar-8
-export NM=llvm-nm-8
-export CC=clang-8
-export CXX=clang++-8
+export AR=llvm-ar
+export NM=llvm-nm
+export CC=clang
+export CXX=clang++
 
 # hack to allow clang to find the default cfi_blacklist.txt
-export CXXFLAGS+=-resource-dir=$(shell clang-8 --print-resource-dir) \
+export CXXFLAGS+=-resource-dir=$(shell clang --print-resource-dir) \
 
-export CPPFLAGS+=-resource-dir=$(shell clang-8 --print-resource-dir) \
+export CPPFLAGS+=-resource-dir=$(shell clang --print-resource-dir) \
 
-export CFLAGS+=-resource-dir=$(shell clang-8 --print-resource-dir) \
+export CFLAGS+=-resource-dir=$(shell clang --print-resource-dir) \
 
 # more verbose linker output
 export LDFLAGS+=-Wl,--stats


### PR DESCRIPTION
This branch is based on `ubuntu_disco` with a few changes:

- Use latest version of Clang and LLVM (as of this PR, version 9).
- Add `equivs` package as essential requirement (this is needed to run `mk-build-deps`).

TODO on merge:

- Create the `ubuntu_eoan` branch.