### PR TITLE
ubuntu_eoan: update to 78.0.3904.108-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ cd build/src
 # Final setup steps for debian/ directory
 ./debian/rules setup-debian
 
+# Add packages for LLVM 9
+# One way to do this is to install from universe:
+# 1. Add this line to your /etc/apt/sources.list: deb http://archive.ubuntu.com/ubuntu/ eoan main universe
+# 2. Run "apt update"
+#
+# Another way is to use the APT repo from apt.llvm.org
+# 1. Add this line to your /etc/apt/sources.list: deb http://apt.llvm.org/eoan/ llvm-toolchain-eoan-9 main
+# 2. Follow the instructions on https://apt.llvm.org for adding the signing key
+# 3. Run "apt update"
+#
+# You do not need to install LLVM packages yourself, since the next step will do it for you.
+
 # Install remaining requirements to build Chromium
 sudo mk-build-deps -i debian/control
 rm ungoogled-chromium-build-deps_*.deb

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+chromium (78.0.3904.108-1) unstable; urgency=medium
+
+  * New upstream security release.
+    - CVE-2019-13723: Use-after-free in Bluetooth. Reported by Yuxiang Li
+    - CVE-2019-13724: Out-of-bounds in Bluetooth. Reported by Yuxiang Li
+  * Disable vaapi on armhf (closes: #944627).
+
+ -- Michael Gilbert <mgilbert@debian.org>  Wed, 20 Nov 2019 23:46:06 +0000
+
 chromium (78.0.3904.97-1) unstable; urgency=medium
 
   * New upstream security release.

--- a/debian/control
+++ b/debian/control
@@ -9,9 +9,9 @@ Standards-Version: 4.4.0
 Rules-Requires-Root: no
 Build-Depends:
  debhelper (>= 11),
- clang,
- lld,
- llvm-dev,
+ clang-9,
+ lld-9,
+ llvm-9-dev,
  python,
  python3,
  python3-debian,

--- a/debian/rules
+++ b/debian/rules
@@ -10,17 +10,17 @@ export DEB_BUILD_MAINT_OPTIONS=hardening=+all
 export DEB_RULES_REQUIRES_ROOT=no
 
 # use system LLVM via unbundling
-export AR=llvm-ar
-export NM=llvm-nm
-export CC=clang
-export CXX=clang++
+export AR=llvm-ar-9
+export NM=llvm-nm-9
+export CC=clang-9
+export CXX=clang++-9
 
 # hack to allow clang to find the default cfi_blacklist.txt
-export CXXFLAGS+=-resource-dir=$(shell clang --print-resource-dir) \
+export CXXFLAGS+=-resource-dir=$(shell clang-9 --print-resource-dir) \
 
-export CPPFLAGS+=-resource-dir=$(shell clang --print-resource-dir) \
+export CPPFLAGS+=-resource-dir=$(shell clang-9 --print-resource-dir) \
 
-export CFLAGS+=-resource-dir=$(shell clang --print-resource-dir) \
+export CFLAGS+=-resource-dir=$(shell clang-9 --print-resource-dir) \
 
 # more verbose linker output
 export LDFLAGS+=-Wl,--stats

--- a/debian/rules
+++ b/debian/rules
@@ -58,16 +58,16 @@ defines+=custom_toolchain=\"//build/toolchain/linux/unbundle:default\"
 # set the appropriate cpu architecture
 DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
 ifeq (i386,$(DEB_HOST_ARCH))
-defines+=host_cpu=\"x86\"
+defines+=host_cpu=\"x86\" use_vaapi=true
 endif
 ifeq (amd64,$(DEB_HOST_ARCH))
-defines+=host_cpu=\"x64\"
+defines+=host_cpu=\"x64\" use_vaapi=true
 endif
 ifeq (arm64,$(DEB_HOST_ARCH))
-defines+=host_cpu=\"arm64\"
+defines+=host_cpu=\"arm64\" use_vaapi=true
 endif
 ifeq (armhf,$(DEB_HOST_ARCH))
-defines+=host_cpu=\"arm\" arm_use_neon=false symbol_level=0
+defines+=host_cpu=\"arm\" use_vaapi=false arm_use_neon=false symbol_level=0 use_vaapi=true
 endif
 
 # disabled features
@@ -96,7 +96,6 @@ defines+=is_debug=false \
 
 # enabled features
 defines+=use_gio=true \
-         use_vaapi=true \
          use_pulseaudio=true \
          link_pulseaudio=true \
          enable_widevine=true \


### PR DESCRIPTION
* Add documentation from `debian_buster` branch about how to install LLVM.
* Explicitly using `*-9` Clang/LLVM packages (which are interchangeable with the non-specific packages for eoan) allows us to also use packages from https://apt-llvm.org (which doesn't have the "undashed" packages).