### PR TITLE
Fix google translate

### DIFF
--- a/debian/scripts/setup
+++ b/debian/scripts/setup
@@ -1,8 +1,9 @@
 #!/bin/bash -eu
 
 DEBIAN=$(pwd)/debian
-UNGOOGLED_CHROMIUM=$DEBIAN/ungoogled-upstream/ungoogled-chromium
+PATCHES=$DEBIAN/patches
 SCRIPTS=$DEBIAN/scripts
+UNGOOGLED_CHROMIUM=$DEBIAN/ungoogled-upstream/ungoogled-chromium
 UTILS=$UNGOOGLED_CHROMIUM/utils
 
 setup_source()
@@ -16,6 +17,28 @@ setup_source()
     python3 -B $UTILS/prune_binaries.py $ROOT $UNGOOGLED_CHROMIUM/pruning.list
     $SCRIPTS/remove_copyright_excluded $ROOT
     (cd $ROOT && $SCRIPTS/check-upstream)
+}
+
+translate_rules()
+{
+sed -e '/^--- a\/.*\/spellcheck_hunspell_dictionary\.cc$/,/^--- a\//{//!d}' \
+    -e '/^--- a\/.*\/translate_url_fetcher\.cc$/,/^--- a\//{//!d}' \
+    -e '/^--- a\/.*\/translate_util\.cc$/,/^--- a\//{//!d}' \
+    -e '/spellcheck_hunspell_dictionary/{g;d}' \
+    -e '/translate/{g;d}' \
+    -i $PATCHES/core/iridium-browser/all-add-trk-prefixes-to-possibly-evil-connections.patch
+
+if [ -z "$(grep 'google translate domain substitutions' $DEBIAN/rules)" ]; then
+    sed -e '/debian\/scripts\/apply_domainsubstitution/a\
+	# revert google translate domain substitutions\
+	\./debian/scripts/translate_domsubs revert'\
+\
+        -e '/^override_dh_prep:/a\
+	# re-apply google translate domain substitutions\
+	\./debian/scripts/translate_domsubs apply'\
+\
+        -i $DEBIAN/rules
+fi
 }
 
 case "$1" in
@@ -37,6 +60,10 @@ orig-source)
     setup_source $EXTRACT
     tar -c $EXTRACT | xz -9 > ../ungoogled-chromium_$VERSION.orig.tar.xz
     rm -rf $EXTRACT
+    ;;
+
+translate-enable)
+    translate_rules
     ;;
 
 esac

--- a/debian/scripts/translate_domsubs
+++ b/debian/scripts/translate_domsubs
@@ -1,0 +1,33 @@
+#!/bin/sh -e
+
+case $1 in
+  revert)
+    a='9oo91eapis\.qjz9zk'
+    b='googleapis\.com'
+    ;;
+
+  apply)
+    a='googleapis\.com'
+    b='9oo91eapis\.qjz9zk'
+    ;;
+
+  *)
+    exit 1
+    ;;
+esac
+
+CDIR=$(dirname $0)
+
+for f in \
+  chrome/browser/translate/translate_manager_browsertest.cc \
+  components/translate/core/browser/translate_script.cc \
+  components/translate/core/common/translate_util.cc
+do
+  if [ ! -e $CDIR/../../$f ]; then
+    printf '%s\n' "WARN: Cannot find $f"
+    continue
+  fi
+  sed -i "s@\(translate\.\)$a@\1$b@g" $CDIR/../../$f
+done
+
+exit $?


### PR DESCRIPTION
This allows users to compile with google translate enabled. Although this capability is now behind a flag, enabling it doesn't work due to the effects of domain substitution.

Refer to the commit message for a full explanation.