### PR TITLE
symlink chromedriver into search patch

### DIFF
--- a/debian/ungoogled-chromium.links
+++ b/debian/ungoogled-chromium.links
@@ -1,1 +1,2 @@
 usr/share/icons/hicolor/48x48/apps/chromium.png usr/share/pixmaps/chromium.png
+usr/lib/chromium/chromedriver usr/bin/chromedriver


### PR DESCRIPTION
Having the chromedriver binary available on the standard search path will enable browser automation software such as selenium to automatically find the chromedriver exacutable and enable it to interact with chromium.

Implements https://github.com/ungoogled-software/ungoogled-chromium-debian/issues/272