### PR TITLE
Optimize the building script by making a shallow clone

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -38,7 +38,7 @@ regenerate it eventually with a new expiration date.
 sudo apt install -y devscripts equivs
 
 # Clone repository and switch to it (optional if are already in it)
-git clone https://github.com/ungoogled-software/ungoogled-chromium-debian.git
+git clone --depth 1 https://github.com/ungoogled-software/ungoogled-chromium-debian.git
 cd ungoogled-chromium-debian
 
 # Initiate the submodules (optional if they are already initiated)


### PR DESCRIPTION
### Brief
This pull request includes a small change to the `.github/README.md` file. The change modifies the `git clone` command to use the `--depth 1` option, which reduces the clone size by only fetching the latest commit.

This reduces the download time from approximately `1.05s user 0.23s system 65% cpu 1.947 total` to approximately `user 0.04s system 10% cpu 0.999 total` in my case and the download size from `7.6 megabytes` to `540 kilobytes`.